### PR TITLE
Pi server/lcd

### DIFF
--- a/PiServer/flaskr/sim.py
+++ b/PiServer/flaskr/sim.py
@@ -8,6 +8,9 @@ from flaskr.db import get_db
 
 from .hardware import led, lcd
 
+# initially set lcd to white background
+lcd.setRGB(255, 255, 255)
+
 bp = Blueprint('sim', __name__, url_prefix='/sim')
 
 @bp.route("/led", methods=["POST"])

--- a/PiServer/ip_address.py
+++ b/PiServer/ip_address.py
@@ -1,0 +1,19 @@
+import socket
+import flaskr.hardware.lcd as lcd
+
+# A function to get the IP address of the Raspberry Pi
+def get_ip_address():
+    ip_address = ""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(('8.8.8.8', 80))
+        ip_address = s.getsockname()[0]
+        s.close()
+    except:
+        ip_address = "Error"
+    finally:
+        return ip_address
+
+# Set Rgb to white
+lcd.setRGB(255, 255, 255)
+lcd.setText(get_ip_address())


### PR DESCRIPTION
## 📑 Beschreibung
Dieser PR sorgt dafür, dass der Hintergrund des LCD beim Start auf weiß gesetzt wird. Dies sorgt für eine bessere Lesbarkeit des Textes.

Außerdem wird ein Script hinzugefügt, welches es ermöglicht, die IP Adresse des Pi auf dem LCD anzuzeigen.